### PR TITLE
disable pip cache to run in memory-constrained environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pymongo==3.0.3
 pyparsing==2.0.3
 python-dateutil==2.4.2
 pytz==2015.4
-requests==2.9.1
+requests==2.7
 six==1.9.0
 Werkzeug==0.10.4
 wheel==0.24.0

--- a/tactic_app/Dockerfile-tile
+++ b/tactic_app/Dockerfile-tile
@@ -1,7 +1,7 @@
 FROM ruimashita/scikit-learn:latest
 WORKDIR /code
 ADD ./tile_container_env/requirements.txt /code/requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 MAINTAINER "Bruce L Sherin"
 ADD  ./tile_container_env /code
 ADD ./qworker.py /code


### PR DESCRIPTION
In order to get the docker container to build on my low-memory EC2 instance I had to disable the pip cache. Shouldn't have any effect on the app.